### PR TITLE
Fix coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
             - libcurl4-openssl-dev
             - libelf-dev
             - libdw-dev
+            - libbfd-dev
 
 # Load travis-cargo.
 before_script:
@@ -37,4 +38,4 @@ script:
 
 after_success:
     # Measure code coverage and upload to coveralls.io.
-    - travis-cargo coveralls --no-sudo --verify
+    - travis-cargo --only stable coveralls --no-sudo --verify


### PR DESCRIPTION
Now coverage checks will start only on stable. 
Also `kcov` throws warning

```
kcov: warning: kcov: WARNING: kcov has been built without libbfd-dev (or
kcov: binutils-dev), so the --verify option will not do anything.
```

and exits with non-zero code, so the coverage didn't upload.
This changes should fix it
